### PR TITLE
To strict

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -32,7 +32,7 @@ ParquetFiles = "0.2"
 Query = "0.12"
 Reexport = "0.2"
 StatFiles = "0.8"
-VegaLite = "1, 2.0"
+VegaLite = "1, 2"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
I got downgraded:

  [112f6efa] ↓ VegaLite v2.1.3 ⇒ v1.0.0

I'm not sure why it didn't go to 2.0.x, but I guess my PR fixes it. Possibly "1, 2.0, 2.1, 2.3" more correct?